### PR TITLE
New branch that contains namelist info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,29 +10,17 @@ Model code to run the CESM2-CMIP5 experiments
 
 To obtain the CESM code you need to do the following:
 
-#. Clone the repository. ::
+1. Clone the repository ::
 
       git clone https://github.com/NCAR/CESM2-CMIP5 --branch cesm2-cmip5-tag  cesm2-cmip5-tag 
       
-   This will create a directory ``cesm2-cmip5-tag`` in your current working directory.
+This will create a directory ``cesm2-cmip5-tag`` in your current working directory.
 
-#. Go into the created directory and check out the externals . ::
+2. Go into the created directory and check out the externals  ::
 
       cd cesm2-cmip5-tag
       ./manage_externals/checkout_externals 
-
-
-Case directories of the CESM2-CMIP5 experiments
-===============================================
-
-The case directories of the CESM2-CMIP5 experiments are available at: 
-    
-      `https://github.com/NCAR/CESM2-CMIP5/tags`
-
-To obtain a specific case directory (for instance: b.e21.B1850.f09_g17.cesm2-cmip5.001), you need to do the following ::
-
-      git clone https://github.com/NCAR/CESM2-CMIP5 \
-      --branch b.e21.B1850.f09_g17.cesm2-cmip5.001  b.e21.B1850.f09_g17.cesm2-cmip5.001
+      
 
 
 Comparing namelists for CESM1, CESM2 and CESM2-CMIP5 experiments
@@ -40,5 +28,25 @@ Comparing namelists for CESM1, CESM2 and CESM2-CMIP5 experiments
 
 To obtain the namelists of the CESM1, CESM2 and CESM2-CMIP5 experiments, you need to do the following ::
 
-      git clone https://github.com/cecilehannay/CESM2-CMIP5  --branch namelists  namelists
+      git clone https://github.com/NCAR/CESM2-CMIP5  --branch namelists  namelists
+      
+      
+
+Case directories of the CESM2-CMIP5 experiments
+===============================================
+
+The case directories of the following CESM2-CMIP5 experiments are available ::
+
+      b.e21.B1850.f09_g17.cesm2-cmip5.001: pi-control (500 years)
+      b.e21.BHIST.f09_g17.cesm2-cmip5.001: historical (1850-2005)  
+      b.e21.BRCP85.f09_g17.cesm2-cmip5.001: rcp85 (2006-2100)
+      b.e21.BRCP85.f09_g17.cesm2-cmip5.101: rcp85 (2006-2100) with bugfix for num_a2
+
+To obtain a specific case directory (for instance: b.e21.B1850.f09_g17.cesm2-cmip5.001), you need to do the following ::
+
+      git clone https://github.com/NCAR/CESM2-CMIP5 \
+      --branch b.e21.B1850.f09_g17.cesm2-cmip5.001  b.e21.B1850.f09_g17.cesm2-cmip5.001
+
+
+
 

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,7 @@ To obtain a specific case directory (for instance: b.e21.B1850.f09_g17.cesm2-cmi
 Comparing namelists for CESM1, CESM2 and CESM2-CMIP5 experiments
 ================================================================
 
-The namelists of CESM1, CESM2 and CESM2-CMIP5 experiments are available at:
+To obtain the namelists of the CESM1, CESM2 and CESM2-CMIP5 experiments, you need to do the following ::
 
-To obtain the namelists, you need to do the following:
-
-      git clone https://github.com/cecilehannay/CESM2-CMIP5 \
-      --branch namelists  namelists
+      git clone https://github.com/cecilehannay/CESM2-CMIP5  --branch namelists  namelists
 

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ CESM2-CMIP5
 This repository contains the model code and case setups for the CESM2-CMIP5 Forcing Experiment
 
 
-Obtaining the model code to run the CESM2-CMIP5 experiments
-===========================================================
+Model code to run the CESM2-CMIP5 experiments
+=============================================
 
 To obtain the CESM code you need to do the following:
 
@@ -33,3 +33,15 @@ To obtain a specific case directory (for instance: b.e21.B1850.f09_g17.cesm2-cmi
 
       git clone https://github.com/NCAR/CESM2-CMIP5 \
       --branch b.e21.B1850.f09_g17.cesm2-cmip5.001  b.e21.B1850.f09_g17.cesm2-cmip5.001
+
+
+Comparing namelists for CESM1, CESM2 and CESM2-CMIP5 experiments
+================================================================
+
+The namelists of CESM1, CESM2 and CESM2-CMIP5 experiments are available at:
+
+To obtain the namelists, you need to do the following:
+
+      git clone https://github.com/cecilehannay/CESM2-CMIP5 \
+      --branch namelists  namelists
+


### PR DESCRIPTION
I created a branch "namelists" that contains the info about namelist of CESM1, CESM2, CESM2-CIMP5. 
I would like that branch to be added to the base repo.

![Screen Shot 2022-01-27 at 9 45 29 AM](https://user-images.githubusercontent.com/9723220/151404533-6cc401f1-ac2b-4ebd-ac0f-1d3997fb844f.png)

